### PR TITLE
feat: Multiple Output Formats Support - Phase 1 (Config Layer)

### DIFF
--- a/meetscribe/core/config.py
+++ b/meetscribe/core/config.py
@@ -5,7 +5,7 @@ Supports YAML-based pipeline configuration.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 from pathlib import Path
 import yaml
 
@@ -36,10 +36,15 @@ class LLMConfig:
 
 @dataclass
 class OutputConfig:
-    """Configuration for OUTPUT layer."""
+    """Configuration for OUTPUT layer with multiple outputs support."""
 
     format: str
     params: Dict[str, Any] = field(default_factory=dict)
+    enabled: bool = True
+    on_error: str = "continue"  # "continue" or "stop"
+    execution_group: int = 0  # 0 = parallel, 1+ = serial groups
+    depends_on: list = field(default_factory=list)
+    wait_for_group: bool = True
 
 
 @dataclass
@@ -49,10 +54,12 @@ class PipelineConfig:
     input: InputConfig
     convert: ConvertConfig
     llm: LLMConfig
-    output: OutputConfig
+    output: Optional[OutputConfig] = None
+    outputs: Optional[List[OutputConfig]] = None
     working_dir: Path = Path("./meetings")
     cleanup_audio: bool = False
     metadata: Dict[str, Any] = field(default_factory=dict)
+    output_execution_mode: str = "auto"  # "auto", "parallel", "serial"
 
     @classmethod
     def from_yaml(cls, path: Path) -> "PipelineConfig":
@@ -103,28 +110,88 @@ class PipelineConfig:
             params=data['llm'].get('params', {})
         )
 
-        output_cfg = OutputConfig(
-            format=data['output']['format'],
-            params=data['output'].get('params', {})
-        )
+        # Handle both single output (legacy) and multiple outputs
+        output_cfg = None
+        outputs_cfg = None
+
+        if 'output' in data:
+            # Legacy single output format
+            output_cfg = OutputConfig(
+                format=data['output']['format'],
+                params=data['output'].get('params', {}),
+                enabled=data['output'].get('enabled', True),
+                on_error=data['output'].get('on_error', 'continue'),
+                execution_group=data['output'].get('execution_group', 0),
+                depends_on=data['output'].get('depends_on', []),
+                wait_for_group=data['output'].get('wait_for_group', True)
+            )
+
+        if 'outputs' in data:
+            # Multiple outputs format
+            outputs_cfg = [
+                OutputConfig(
+                    format=output['format'],
+                    params=output.get('params', {}),
+                    enabled=output.get('enabled', True),
+                    on_error=output.get('on_error', 'continue'),
+                    execution_group=output.get('execution_group', 0),
+                    depends_on=output.get('depends_on', []),
+                    wait_for_group=output.get('wait_for_group', True)
+                )
+                for output in data['outputs']
+            ]
 
         working_dir = Path(data.get('working_dir', './meetings'))
         cleanup_audio = data.get('cleanup_audio', False)
         metadata = data.get('metadata', {})
+        output_execution_mode = data.get('output_execution_mode', 'auto')
 
         return cls(
             input=input_cfg,
             convert=convert_cfg,
             llm=llm_cfg,
             output=output_cfg,
+            outputs=outputs_cfg,
             working_dir=working_dir,
             cleanup_audio=cleanup_audio,
-            metadata=metadata
+            metadata=metadata,
+            output_execution_mode=output_execution_mode
         )
+
+    def get_output_configs(self) -> List[OutputConfig]:
+        """
+        Get list of enabled output configurations.
+
+        Returns:
+            List of OutputConfig instances (filters out disabled outputs)
+        """
+        if self.outputs:
+            # Multiple outputs - filter enabled only
+            return [cfg for cfg in self.outputs if cfg.enabled]
+        elif self.output:
+            # Legacy single output
+            return [self.output] if self.output.enabled else []
+        else:
+            return []
+
+    def get_execution_groups(self) -> Dict[int, List[OutputConfig]]:
+        """
+        Group outputs by execution_group for serial/parallel execution.
+
+        Returns:
+            Dictionary mapping execution_group -> list of OutputConfig
+        """
+        groups: Dict[int, List[OutputConfig]] = {}
+        for output_cfg in self.get_output_configs():
+            group_id = output_cfg.execution_group
+            if group_id not in groups:
+                groups[group_id] = []
+            groups[group_id].append(output_cfg)
+        return groups
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert config to dictionary."""
-        return {
+        result = {
             'input': {
                 'provider': self.input.provider,
                 'params': self.input.params
@@ -137,14 +204,33 @@ class PipelineConfig:
                 'engine': self.llm.engine,
                 'params': self.llm.params
             },
-            'output': {
-                'format': self.output.format,
-                'params': self.output.params
-            },
             'working_dir': str(self.working_dir),
             'cleanup_audio': self.cleanup_audio,
-            'metadata': self.metadata
+            'metadata': self.metadata,
+            'output_execution_mode': self.output_execution_mode
         }
+
+        # Include output or outputs depending on which is set
+        if self.outputs:
+            result['outputs'] = [
+                {
+                    'format': cfg.format,
+                    'params': cfg.params,
+                    'enabled': cfg.enabled,
+                    'on_error': cfg.on_error,
+                    'execution_group': cfg.execution_group,
+                    'depends_on': cfg.depends_on,
+                    'wait_for_group': cfg.wait_for_group
+                }
+                for cfg in self.outputs
+            ]
+        elif self.output:
+            result['output'] = {
+                'format': self.output.format,
+                'params': self.output.params
+            }
+
+        return result
 
     def save(self, path: Path):
         """

--- a/tests/test_config_multiple_outputs.py
+++ b/tests/test_config_multiple_outputs.py
@@ -1,0 +1,380 @@
+"""
+Tests for multiple outputs configuration support.
+
+This test suite covers Phase 1: Config Layer implementation
+for Issue #200 - Multiple Output Formats Support.
+"""
+
+import pytest
+from pathlib import Path
+from meetscribe.core.config import (
+    OutputConfig,
+    PipelineConfig,
+    InputConfig,
+    ConvertConfig,
+    LLMConfig
+)
+
+
+class TestOutputConfig:
+    """Test OutputConfig with new fields for multiple outputs support."""
+
+    def test_output_config_basic(self):
+        """Test basic OutputConfig creation."""
+        config = OutputConfig(
+            format="markdown",
+            params={"output_dir": "./meetings"}
+        )
+        assert config.format == "markdown"
+        assert config.params["output_dir"] == "./meetings"
+
+    def test_output_config_with_enabled_flag(self):
+        """Test OutputConfig with enabled flag."""
+        config = OutputConfig(
+            format="pdf",
+            params={},
+            enabled=True
+        )
+        assert config.enabled is True
+
+    def test_output_config_disabled(self):
+        """Test OutputConfig can be disabled."""
+        config = OutputConfig(
+            format="json",
+            params={},
+            enabled=False
+        )
+        assert config.enabled is False
+
+    def test_output_config_default_enabled_is_true(self):
+        """Test OutputConfig defaults to enabled=True."""
+        config = OutputConfig(format="url")
+        assert config.enabled is True
+
+    def test_output_config_with_on_error_strategy(self):
+        """Test OutputConfig with error handling strategy."""
+        config = OutputConfig(
+            format="markdown",
+            on_error="continue"
+        )
+        assert config.on_error == "continue"
+
+        config2 = OutputConfig(
+            format="pdf",
+            on_error="stop"
+        )
+        assert config2.on_error == "stop"
+
+    def test_output_config_default_on_error_is_continue(self):
+        """Test OutputConfig defaults to on_error='continue'."""
+        config = OutputConfig(format="json")
+        assert config.on_error == "continue"
+
+    def test_output_config_with_execution_group(self):
+        """Test OutputConfig with execution_group for serial execution."""
+        config = OutputConfig(
+            format="pdf",
+            execution_group=1
+        )
+        assert config.execution_group == 1
+
+    def test_output_config_default_execution_group_is_zero(self):
+        """Test OutputConfig defaults to execution_group=0 (parallel)."""
+        config = OutputConfig(format="markdown")
+        assert config.execution_group == 0
+
+    def test_output_config_with_dependencies(self):
+        """Test OutputConfig with depends_on list."""
+        config = OutputConfig(
+            format="discord_webhook",
+            depends_on=["pdf", "markdown"]
+        )
+        assert config.depends_on == ["pdf", "markdown"]
+
+    def test_output_config_default_depends_on_is_empty(self):
+        """Test OutputConfig defaults to empty depends_on list."""
+        config = OutputConfig(format="json")
+        assert config.depends_on == []
+
+    def test_output_config_with_wait_for_group(self):
+        """Test OutputConfig with wait_for_group flag."""
+        config = OutputConfig(
+            format="pdf",
+            execution_group=1,
+            wait_for_group=True
+        )
+        assert config.wait_for_group is True
+
+    def test_output_config_default_wait_for_group_is_true(self):
+        """Test OutputConfig defaults to wait_for_group=True."""
+        config = OutputConfig(format="markdown")
+        assert config.wait_for_group is True
+
+
+class TestPipelineConfigMultipleOutputs:
+    """Test PipelineConfig with multiple outputs support."""
+
+    def test_pipeline_config_with_single_output_legacy(self):
+        """Test backward compatibility with single output config."""
+        config_dict = {
+            'input': {'provider': 'file', 'params': {}},
+            'convert': {'engine': 'passthrough', 'params': {}},
+            'llm': {'engine': 'notebooklm', 'params': {}},
+            'output': {'format': 'url', 'params': {}}
+        }
+        config = PipelineConfig.from_dict(config_dict)
+
+        assert config.output.format == 'url'
+        # Should work with legacy single output
+
+    def test_pipeline_config_with_multiple_outputs(self):
+        """Test PipelineConfig with outputs list."""
+        config_dict = {
+            'input': {'provider': 'file', 'params': {}},
+            'convert': {'engine': 'passthrough', 'params': {}},
+            'llm': {'engine': 'notebooklm', 'params': {}},
+            'outputs': [
+                {'format': 'url', 'params': {}},
+                {'format': 'markdown', 'params': {'output_dir': './meetings'}},
+                {'format': 'json', 'params': {}}
+            ]
+        }
+        config = PipelineConfig.from_dict(config_dict)
+
+        # Should have outputs attribute
+        assert hasattr(config, 'outputs')
+        assert len(config.outputs) == 3
+        assert config.outputs[0].format == 'url'
+        assert config.outputs[1].format == 'markdown'
+        assert config.outputs[2].format == 'json'
+
+    def test_pipeline_config_get_output_configs_single(self):
+        """Test get_output_configs() returns list for single output."""
+        config_dict = {
+            'input': {'provider': 'file', 'params': {}},
+            'convert': {'engine': 'passthrough', 'params': {}},
+            'llm': {'engine': 'notebooklm', 'params': {}},
+            'output': {'format': 'markdown', 'params': {}}
+        }
+        config = PipelineConfig.from_dict(config_dict)
+
+        output_configs = config.get_output_configs()
+        assert isinstance(output_configs, list)
+        assert len(output_configs) == 1
+        assert output_configs[0].format == 'markdown'
+
+    def test_pipeline_config_get_output_configs_multiple(self):
+        """Test get_output_configs() returns outputs list."""
+        config_dict = {
+            'input': {'provider': 'file', 'params': {}},
+            'convert': {'engine': 'passthrough', 'params': {}},
+            'llm': {'engine': 'notebooklm', 'params': {}},
+            'outputs': [
+                {'format': 'url'},
+                {'format': 'markdown'},
+                {'format': 'pdf'}
+            ]
+        }
+        config = PipelineConfig.from_dict(config_dict)
+
+        output_configs = config.get_output_configs()
+        assert len(output_configs) == 3
+        assert all(isinstance(cfg, OutputConfig) for cfg in output_configs)
+
+    def test_pipeline_config_get_output_configs_filters_disabled(self):
+        """Test get_output_configs() filters out disabled outputs."""
+        config_dict = {
+            'input': {'provider': 'file', 'params': {}},
+            'convert': {'engine': 'passthrough', 'params': {}},
+            'llm': {'engine': 'notebooklm', 'params': {}},
+            'outputs': [
+                {'format': 'url', 'enabled': True},
+                {'format': 'markdown', 'enabled': False},
+                {'format': 'json', 'enabled': True}
+            ]
+        }
+        config = PipelineConfig.from_dict(config_dict)
+
+        output_configs = config.get_output_configs()
+        assert len(output_configs) == 2
+        assert output_configs[0].format == 'url'
+        assert output_configs[1].format == 'json'
+
+    def test_pipeline_config_get_execution_groups(self):
+        """Test get_execution_groups() returns grouped outputs."""
+        config_dict = {
+            'input': {'provider': 'file', 'params': {}},
+            'convert': {'engine': 'passthrough', 'params': {}},
+            'llm': {'engine': 'notebooklm', 'params': {}},
+            'outputs': [
+                {'format': 'url', 'execution_group': 0},
+                {'format': 'markdown', 'execution_group': 0},
+                {'format': 'pdf', 'execution_group': 1},
+                {'format': 'discord_webhook', 'execution_group': 2}
+            ]
+        }
+        config = PipelineConfig.from_dict(config_dict)
+
+        groups = config.get_execution_groups()
+        assert isinstance(groups, dict)
+        assert 0 in groups
+        assert 1 in groups
+        assert 2 in groups
+        assert len(groups[0]) == 2  # url, markdown
+        assert len(groups[1]) == 1  # pdf
+        assert len(groups[2]) == 1  # discord_webhook
+
+    def test_pipeline_config_with_output_execution_mode(self):
+        """Test PipelineConfig with output_execution_mode."""
+        config_dict = {
+            'input': {'provider': 'file', 'params': {}},
+            'convert': {'engine': 'passthrough', 'params': {}},
+            'llm': {'engine': 'notebooklm', 'params': {}},
+            'outputs': [
+                {'format': 'url'},
+                {'format': 'markdown'}
+            ],
+            'output_execution_mode': 'parallel'
+        }
+        config = PipelineConfig.from_dict(config_dict)
+
+        assert config.output_execution_mode == 'parallel'
+
+    def test_pipeline_config_default_execution_mode_is_auto(self):
+        """Test PipelineConfig defaults to output_execution_mode='auto'."""
+        config_dict = {
+            'input': {'provider': 'file', 'params': {}},
+            'convert': {'engine': 'passthrough', 'params': {}},
+            'llm': {'engine': 'notebooklm', 'params': {}},
+            'outputs': [{'format': 'url'}]
+        }
+        config = PipelineConfig.from_dict(config_dict)
+
+        assert config.output_execution_mode == 'auto'
+
+    def test_pipeline_config_execution_mode_validation(self):
+        """Test output_execution_mode only accepts valid values."""
+        valid_modes = ['auto', 'parallel', 'serial']
+
+        for mode in valid_modes:
+            config_dict = {
+                'input': {'provider': 'file', 'params': {}},
+                'convert': {'engine': 'passthrough', 'params': {}},
+                'llm': {'engine': 'notebooklm', 'params': {}},
+                'outputs': [{'format': 'url'}],
+                'output_execution_mode': mode
+            }
+            config = PipelineConfig.from_dict(config_dict)
+            assert config.output_execution_mode == mode
+
+
+class TestPipelineConfigYAMLParsing:
+    """Test YAML parsing for multiple outputs."""
+
+    def test_parse_yaml_with_multiple_outputs(self, tmp_path):
+        """Test parsing YAML file with multiple outputs."""
+        yaml_content = """
+input:
+  provider: file
+  params:
+    audio_path: ./sample.mp3
+
+convert:
+  engine: passthrough
+  params: {}
+
+llm:
+  engine: notebooklm
+  params: {}
+
+outputs:
+  - format: url
+    params:
+      save_metadata: true
+  - format: markdown
+    params:
+      output_dir: ./meetings
+  - format: json
+    params:
+      output_dir: ./meetings
+"""
+        config_file = tmp_path / "test_config.yaml"
+        config_file.write_text(yaml_content)
+
+        config = PipelineConfig.from_yaml(config_file)
+
+        assert len(config.get_output_configs()) == 3
+        assert config.get_output_configs()[0].format == 'url'
+        assert config.get_output_configs()[1].format == 'markdown'
+        assert config.get_output_configs()[2].format == 'json'
+
+    def test_parse_yaml_with_execution_groups(self, tmp_path):
+        """Test parsing YAML with execution_group and depends_on."""
+        yaml_content = """
+input:
+  provider: file
+  params: {}
+
+convert:
+  engine: passthrough
+  params: {}
+
+llm:
+  engine: notebooklm
+  params: {}
+
+outputs:
+  - format: url
+    execution_group: 0
+  - format: markdown
+    execution_group: 0
+  - format: pdf
+    execution_group: 1
+    params:
+      output_dir: ./meetings
+  - format: discord_webhook
+    execution_group: 2
+    depends_on: ["pdf"]
+    params:
+      webhook_url: "https://discord.com/api/webhooks/xxx"
+"""
+        config_file = tmp_path / "test_config.yaml"
+        config_file.write_text(yaml_content)
+
+        config = PipelineConfig.from_yaml(config_file)
+        groups = config.get_execution_groups()
+
+        assert len(groups[0]) == 2
+        assert len(groups[1]) == 1
+        assert len(groups[2]) == 1
+        assert config.outputs[3].depends_on == ["pdf"]
+
+    def test_backward_compatibility_single_output(self, tmp_path):
+        """Test backward compatibility with old single output format."""
+        yaml_content = """
+input:
+  provider: file
+  params: {}
+
+convert:
+  engine: passthrough
+  params: {}
+
+llm:
+  engine: notebooklm
+  params: {}
+
+output:
+  format: markdown
+  params:
+    output_dir: ./meetings
+"""
+        config_file = tmp_path / "test_config.yaml"
+        config_file.write_text(yaml_content)
+
+        config = PipelineConfig.from_yaml(config_file)
+
+        # Should still work with get_output_configs()
+        output_configs = config.get_output_configs()
+        assert len(output_configs) == 1
+        assert output_configs[0].format == 'markdown'


### PR DESCRIPTION
## Summary

Implements **Phase 1: Config Layer** of Issue #200 - Multiple Output Formats Support.

This is the first phase of a multi-phase implementation to support generating multiple output formats from a single pipeline run.

### What's Changed

**Extended OutputConfig with new fields:**
- `enabled: bool` (default `True`) - Toggle individual outputs on/off
- `on_error: str` (default `"continue"`) - Error handling strategy (`continue` or `stop`)
- `execution_group: int` (default `0`) - For serial/parallel execution grouping
- `depends_on: List[str]` (default `[]`) - Dependency management between outputs
- `wait_for_group: bool` (default `True`) - Group synchronization flag

**Extended PipelineConfig:**
- `outputs: Optional[List[OutputConfig]]` - Multiple outputs list
- `output_execution_mode: str` (default `"auto"`) - Global execution mode (`auto`, `parallel`, `serial`)
- `get_output_configs()` method - Returns list of enabled outputs
- `get_execution_groups()` method - Groups outputs by execution_group for scheduling

**Backward Compatibility:**
- Existing single `output` field continues to work
- `from_dict()` handles both `output` and `outputs` formats
- `to_dict()` preserves the format used during creation

### Test Coverage

- Added 24 new tests in `tests/test_config_multiple_outputs.py`
- All 50 tests passing (24 new + 26 existing)
- Tests cover:
  - OutputConfig new fields and defaults
  - PipelineConfig multiple outputs support
  - YAML parsing with multiple outputs
  - Backward compatibility with single output format
  - Execution groups and dependencies

### Example Config

**Multiple outputs (new format):**
```yaml
input:
  provider: file
  params:
    audio_path: ./sample.mp3

convert:
  engine: passthrough
  params: {}

llm:
  engine: notebooklm
  params: {}

outputs:
  - format: url
    execution_group: 0
  - format: markdown
    execution_group: 0
    params:
      output_dir: ./meetings
  - format: pdf
    execution_group: 1
    params:
      output_dir: ./meetings
  - format: discord_webhook
    execution_group: 2
    depends_on: ["pdf"]
    params:
      webhook_url: "https://discord.com/api/webhooks/xxx"

output_execution_mode: auto
```

**Single output (legacy format still works):**
```yaml
output:
  format: markdown
  params:
    output_dir: ./meetings
```

### Next Phases

This PR implements only the Config Layer. Future phases will include:

- **Phase 2**: Runner Layer - Implement serial/parallel execution in `runner.py`
- **Phase 3**: Models & Output Tracking - Add output tracking to `Minutes` model
- **Phase 4**: CLI & Display - Update CLI to show multiple outputs progress
- **Phase 5**: Testing & Documentation - E2E tests and user documentation

## Test Plan

- [x] All existing tests pass (26 tests)
- [x] All new config tests pass (24 tests)
- [x] Backward compatibility verified with existing single output format
- [x] YAML parsing works with both formats
- [x] `get_output_configs()` correctly filters disabled outputs
- [x] `get_execution_groups()` correctly groups outputs

## Related Issues

Closes #200 (Phase 1 only - other phases will be implemented in separate PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)